### PR TITLE
https://kybernetwork.atlassian.net/browse/DMM-88 - Fix Broken Pools Data Due To Graphql Caching

### DIFF
--- a/src/pages/Pools/index.tsx
+++ b/src/pages/Pools/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useMemo } from 'react'
 import { Link, RouteComponentProps } from 'react-router-dom'
 import styled from 'styled-components'
 import { Box, Flex } from 'rebass'
@@ -106,19 +106,23 @@ const Pools = ({
     [currencyIdA, history, currencyIdB]
   )
 
-  const poolsList = pairs
-    .map(([pairState, pair]) => pair)
-    .filter(pair => pair !== null)
-    .filter(pair => {
-      if (searchValue) {
-        return pair?.address.includes(searchValue)
-      }
+  const poolsList = useMemo(
+    () =>
+      pairs
+        .map(([pairState, pair]) => pair)
+        .filter(pair => pair !== null)
+        .filter(pair => {
+          if (searchValue) {
+            return pair?.address.includes(searchValue)
+          }
 
-      return true
-    })
+          return true
+        }),
+    [pairs, searchValue]
+  )
 
   // format as array of addresses
-  const formattedPools = poolsList.map(pool => pool?.address.toLowerCase())
+  const formattedPools = useMemo(() => poolsList.map(pool => pool?.address.toLowerCase()), [poolsList])
 
   useResetPools(currencyA ?? undefined, currencyB ?? undefined)
 
@@ -162,7 +166,7 @@ const Pools = ({
         </ToolbarWrapper>
 
         <Panel>
-          {loadingUserLiquidityPositions ? (
+          {loadingUserLiquidityPositions || !poolsData ? (
             <LocalLoader />
           ) : poolsList.length > 0 && poolsData.length > 0 && userLiquidityPositions?.liquidityPositionSnapshots ? (
             <PoolList

--- a/src/state/application/hooks.ts
+++ b/src/state/application/hooks.ts
@@ -149,7 +149,7 @@ export function useETHPrice(): AppState['application']['ethPrice'] {
       }
     }
     checkForEthPrice()
-  }, [ethPrice])
+  }, [ethPrice, dispatch])
 
   return ethPrice
 }

--- a/src/state/pools/hooks.ts
+++ b/src/state/pools/hooks.ts
@@ -123,14 +123,14 @@ export async function getBulkPoolData(poolList: string[], ethPrice?: string): Pr
       variables: {
         allPools: poolList
       },
-      fetchPolicy: 'cache-first'
+      fetchPolicy: 'network-only'
     })
 
     const [oneDayResult, twoDayResult, oneWeekResult] = await Promise.all(
       [b1, b2, bWeek].map(async block => {
         const result = client.query({
           query: POOLS_HISTORICAL_BULK(block, poolList),
-          fetchPolicy: 'cache-first'
+          fetchPolicy: 'network-only'
         })
         return result
       })
@@ -156,7 +156,7 @@ export async function getBulkPoolData(poolList: string[], ethPrice?: string): Pr
           if (!oneDayHistory) {
             const newData = await client.query({
               query: POOL_DATA(pool.id, b1),
-              fetchPolicy: 'cache-first'
+              fetchPolicy: 'network-only'
             })
             oneDayHistory = newData.data.pools[0]
           }
@@ -164,7 +164,7 @@ export async function getBulkPoolData(poolList: string[], ethPrice?: string): Pr
           if (!twoDayHistory) {
             const newData = await client.query({
               query: POOL_DATA(pool.id, b2),
-              fetchPolicy: 'cache-first'
+              fetchPolicy: 'network-only'
             })
             twoDayHistory = newData.data.pools[0]
           }
@@ -172,7 +172,7 @@ export async function getBulkPoolData(poolList: string[], ethPrice?: string): Pr
           if (!oneWeekHistory) {
             const newData = await client.query({
               query: POOL_DATA(pool.id, bWeek),
-              fetchPolicy: 'cache-first'
+              fetchPolicy: 'network-only'
             })
             oneWeekHistory = newData.data.pools[0]
           }
@@ -203,7 +203,7 @@ export function useBulkPoolData(poolList: (string | undefined)[], ethPrice?: str
     }
 
     checkForPools()
-  }, [poolList])
+  }, [dispatch, ethPrice, poolList, poolsData.length])
 
   return poolsData
 }
@@ -213,5 +213,5 @@ export function useResetPools(currencyA: Currency | undefined, currencyB: Curren
 
   useEffect(() => {
     dispatch(updatePools({ pools: [] }))
-  }, [currencyA, currencyB])
+  }, [currencyA, currencyB, dispatch])
 }


### PR DESCRIPTION
At the moment, data in Graphql caching for Pools list is broken (not sure why yet).

So I use `network-only` as a quick fix at the moment (which might affect the performance). I will find a way to optimize it later