### PR TITLE
[DMM-145] [DMM-304] [DMM-320]

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -83,7 +83,7 @@ export const portis = new PortisConnector({
 export const walletlink = new WalletLinkConnector({
   url: NETWORK_URL,
   appName: 'DmmExchange',
-  appLogoUrl: 'https://i.ibb.co/yYH3kwL/favicon.png'
+  appLogoUrl: 'https://dmm.exchange/favicon.png'
 })
 
 export const ledger = new LedgerConnector({

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,10 +9,6 @@ import { isMobile } from 'react-device-detect'
 import { injected, NETWORK_URLS } from '../connectors'
 import { ethers } from 'ethers'
 
-const simpleRpcProvider = new ethers.providers.JsonRpcProvider(
-  'https://polygon.dmm.exchange/v1/mainnet/geth?appId=prod-dmm'
-)
-
 export const providers: {
   [chainId in ChainId]?: any
 } = {

--- a/src/hooks/useWrapCallback.ts
+++ b/src/hooks/useWrapCallback.ts
@@ -56,7 +56,9 @@ export default function useWrapCallback(
                 }
               }
             : undefined,
-        inputError: sufficientBalance
+        inputError: !typedValue
+          ? t`Enter an amount`
+          : sufficientBalance
           ? undefined
           : t`Insufficient ${convertToNativeTokenFromETH(Currency.ETHER, chainId).symbol} balance`
       }
@@ -74,12 +76,14 @@ export default function useWrapCallback(
                 }
               }
             : undefined,
-        inputError: sufficientBalance
+        inputError: !typedValue
+          ? t`Enter an amount`
+          : sufficientBalance
           ? undefined
           : t`Insufficient W${convertToNativeTokenFromETH(Currency.ETHER, chainId).symbol} balance`
       }
     } else {
       return NOT_APPLICABLE
     }
-  }, [wethContract, chainId, inputCurrency, outputCurrency, inputAmount, balance, addTransaction])
+  }, [wethContract, chainId, inputCurrency, outputCurrency, inputAmount, balance, addTransaction, typedValue])
 }

--- a/src/locales/en-US.po
+++ b/src/locales/en-US.po
@@ -492,6 +492,8 @@ msgstr "Enter a recipient"
 msgid "Enter a valid slippage percentage"
 msgstr "Enter a valid slippage percentage"
 
+#: src/hooks/useWrapCallback.ts
+#: src/hooks/useWrapCallback.ts
 #: src/state/burn/hooks.ts
 #: src/state/burn/hooks_sushi.ts
 #: src/state/burn/hooks_uni.ts

--- a/src/locales/ko-KR.po
+++ b/src/locales/ko-KR.po
@@ -492,6 +492,8 @@ msgstr "받는 사람을 입력하세요"
 msgid "Enter a valid slippage percentage"
 msgstr "유효한 슬립페지 비율을 입력하십시오"
 
+#: src/hooks/useWrapCallback.ts
+#: src/hooks/useWrapCallback.ts
 #: src/state/burn/hooks.ts
 #: src/state/burn/hooks_sushi.ts
 #: src/state/burn/hooks_uni.ts

--- a/src/locales/tr-TR.po
+++ b/src/locales/tr-TR.po
@@ -492,6 +492,8 @@ msgstr "Bir alıcı girin"
 msgid "Enter a valid slippage percentage"
 msgstr "Geçerli bir kayma yüzdesi girin"
 
+#: src/hooks/useWrapCallback.ts
+#: src/hooks/useWrapCallback.ts
 #: src/state/burn/hooks.ts
 #: src/state/burn/hooks_sushi.ts
 #: src/state/burn/hooks_uni.ts

--- a/src/locales/vi-VN.po
+++ b/src/locales/vi-VN.po
@@ -492,6 +492,8 @@ msgstr "Nhập người nhận"
 msgid "Enter a valid slippage percentage"
 msgstr "Nhập phần trăm trượt giá hợp lệ"
 
+#: src/hooks/useWrapCallback.ts
+#: src/hooks/useWrapCallback.ts
 #: src/state/burn/hooks.ts
 #: src/state/burn/hooks_sushi.ts
 #: src/state/burn/hooks_uni.ts

--- a/src/locales/zh-CN.po
+++ b/src/locales/zh-CN.po
@@ -492,6 +492,8 @@ msgstr "输入收件人"
 msgid "Enter a valid slippage percentage"
 msgstr "输入有效的滑点百分比"
 
+#: src/hooks/useWrapCallback.ts
+#: src/hooks/useWrapCallback.ts
 #: src/state/burn/hooks.ts
 #: src/state/burn/hooks_sushi.ts
 #: src/state/burn/hooks_uni.ts

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -457,7 +457,7 @@ export default function Swap({ history }: RouteComponentProps) {
                 }
                 error={isValid && priceImpactSeverity > 2 && !swapCallbackError}
               >
-                <Text fontSize={20} fontWeight={500}>
+                <Text fontWeight={500}>
                   {swapInputError
                     ? swapInputError
                     : priceImpactSeverity > 3 && !isExpertMode

--- a/src/state/mint/hooks.ts
+++ b/src/state/mint/hooks.ts
@@ -123,8 +123,14 @@ export function useDerivedMintInfo(
       wrappedCurrencyAmount(currencyAAmount, chainId),
       wrappedCurrencyAmount(currencyBAmount, chainId)
     ]
+
     if (pair && totalSupply && tokenAmountA && tokenAmountB) {
-      return pair.getLiquidityMinted(totalSupply, tokenAmountA, tokenAmountB)
+      try {
+        return pair.getLiquidityMinted(totalSupply, tokenAmountA, tokenAmountB)
+      } catch (e) {
+        console.error(e)
+        return undefined
+      }
     } else {
       return undefined
     }


### PR DESCRIPTION
* [DMM-145] fix(addliquidity): try catch to defend crash page
Reason: Pool have rate to big: 1 ETH = 29960000000000000000 FOT
=> When user input 1 FOT => Can not parse to ETH with that rate because ETH have decimals = 18 
=> Uni lib throw error

Solution: Add try catch to defend crash.

* [DMM-304]: Change DMM logo on wallet link 
* [DMM-320]: When input is blank, show "Enter an amount" instead of "Insufficient" balance